### PR TITLE
Removing scrollbar from page and improving animations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ function App() {
     <div
       className={`flex flex-col ${
         md ? "min-h-screen" : "h-screen"
-      } md:flex-row  font-sans`}
+      } md:flex-row font-sans`}
     >
       <Division
         title={Divisions.About_Me}

--- a/src/components/Division.tsx
+++ b/src/components/Division.tsx
@@ -9,11 +9,11 @@ interface DivisionProps {
 const md = window.screen.width >= 768;
 const smallWidth = `${
   md ? "w-1/10" : "h-1/20"
-} transition-gpu transition-height md:transition-width duration-250 ease-in-out
+} transition-height md:transition-width md:duration-500 ease-in-out duration-500
 `;
 const largeWidth = `${
   md ? "w-3/5" : "h-4/5"
-} md:overflow-y-hidden md:h-auto overflow-y-scroll transition-gpu transition-height md:transition-width duration-250 ease-in-out`;
+} md:overflow-y-hidden md:h-auto overflow-y-scroll transition-height md:transition-width md:duration-500 duration-500 ease-in-out`;
 export const Division = (props: DivisionProps): React.ReactElement => {
   const { selected, handleClick, title } = props;
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,23 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer utilities {
+  @variants responsive {
+    /* Chrome, Safari and Opera */
+    .no-scrollbar::-webkit-scrollbar {
+      display: none;
+    }
+
+    .no-scrollbar {
+      -ms-overflow-style: none; /* IE and Edge */
+      scrollbar-width: none; /* Firefox */
+    }
+  }
+}
+
+@layer base {
+  html {
+    @apply no-scrollbar;
+  }
+}


### PR DESCRIPTION
As the divisions went from small to large, a scrollbar would appear for a very short amount of time, making the page and transition seem jittery. 

Add duration to transition of desktop view